### PR TITLE
fix: resolve GPU memory contention causing child process crashes

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,4 +12,4 @@ COPY . .
 
 EXPOSE 8000
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--timeout-keep-alive", "120", "--workers", "4"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--timeout-keep-alive", "300", "--workers", "1"]

--- a/backend/services/document_service.py
+++ b/backend/services/document_service.py
@@ -15,16 +15,11 @@ class DocumentService:
     def __init__(self):
         self.translation_service = TranslationService()
 
-        # Configure GPU memory management to prevent child process crashes
+        # Log GPU availability without restrictive memory management
         if torch.cuda.is_available():
             gpu_count = torch.cuda.device_count()
             app_logger.info(f"Detected {gpu_count} CUDA devices: {[f'cuda:{i}' for i in range(gpu_count)]}")
-
-            # Set memory management to prevent fragmentation and conflicts
             torch.cuda.empty_cache()
-            # Allow memory to be freed when processes exit
-            import os
-            os.environ['PYTORCH_CUDA_ALLOC_CONF'] = 'max_split_size_mb:128'
         else:
             app_logger.info("No CUDA devices detected, using CPU")
 


### PR DESCRIPTION
- Remove restrictive PYTORCH_CUDA_ALLOC_CONF memory allocation limits
- Reduce uvicorn workers from 4 to 1 to eliminate GPU memory competition
- Increase timeout-keep-alive from 120 to 300 seconds for large PDFs
- Simplify GPU initialization without overly aggressive memory management

✅ Successfully tested with large files (359+ pages) ✅ Resolves "Remote end closed connection" errors
✅ Eliminates child process deaths during PDF finalization

🤖 Generated with [Claude Code](https://claude.ai/code)